### PR TITLE
pr2

### DIFF
--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -29,6 +29,18 @@ class TestConfig:
     # note: can set to True to see SQL queries being executed
     SQLALCHEMY_ECHO = False
 
+    @classmethod
+    def get_db_info(cls):
+        """
+        Provides database info for the test environment, satisfying
+        the interface expected by the application.
+        """
+        return {
+            'db_type': 'sqlite_in_memory',
+            'database_url': cls.SQLALCHEMY_DATABASE_URI,
+            'status': 'configured_for_testing'
+        }
+
 
 @pytest.fixture(scope='module')
 def app():
@@ -512,11 +524,12 @@ class TestWorkshopRegistration:
         mock_authed_user(mock_get_supabase, participant)
 
         # Create a non-overlapping
-        # workshop1 ends at 10:30. This one starts at 10:30.
-        some_datetime = datetime(2025, 9, 10, 10, 30, tzinfo=timezone.utc)
+        workshop3 = db.session.get(Workshop, 3)
+        back_to_back_datetime = workshop3.SessionDateTime + timedelta(minutes=workshop3.DurationMin)
+
         non_overlapping_workshop = Workshop(
             Title="Some Workshop",
-            SessionDateTime=some_datetime,
+            SessionDateTime=back_to_back_datetime,
             DurationMin=60,
             MaxCapacity=10
         )

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -655,7 +655,7 @@ class TestWorkshopRegistration:
         response_waitlist = client.post(f'/workshops/{workshop_id}/register',
                                         headers={'Authorization': f'Bearer {FAKE_JWT}'})
         assert response_waitlist.status_code == 200
-        assert response_waitlist.get_json()['workshop_status'] == 'Waitlisted'
+        assert response_waitlist.get_json()['workshop_status'] == RegistrationStatus.WAITLISTED
 
         # Verify state: 1 registered, 1 waitlisted
         reg_count = Registration.query.filter_by(WorkshopId=workshop_id, Status=RegistrationStatus.REGISTERED).count()
@@ -677,7 +677,7 @@ class TestWorkshopRegistration:
         assert response_register.status_code == 200
         data = response_register.get_json()
         assert data['status'] == 'Signed up successfully'
-        assert data['workshop_status'] == 'Registered'
+        assert data['workshop_status'] == RegistrationStatus.REGISTERED
 
         # Verify in the database that the user's status is now REGISTERED.
         final_reg = Registration.query.filter_by(UserId=user2.UserId, WorkshopId=workshop_id).one()


### PR DESCRIPTION
get, post skills.

last commit returns `models.py` to prev version in which enums were represented as strings. no perf benefits from int's for a small website, and it's more readable and less code as strings. uppercase str representation. frontend can use toUpperCase() (or lower) if worried about case 